### PR TITLE
Fix SonarCloud CI configuration

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Download test artifacts
@@ -36,7 +38,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          args: >
-            -Dsonar.organization=${{ secrets.SONAR_ORGANIZATION }}
-            -Dsonar.projectKey=${{ secrets.SONAR_PROJECT_KEY }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,19 @@
+sonar.projectKey=catch-oss_silverstripe-csp-logging
+sonar.organization=catch-design
+
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=catch-oss_silverstripe-csp-logging
+#sonar.projectVersion=1.0
+
+# Source and test paths
+sonar.sources=src
+sonar.tests=tests
+sonar.sourceEncoding=UTF-8
+
+# PHP settings
+sonar.php.coverage.reportPaths=coverage/php/coverage.xml
+sonar.php.tests.reportPath=coverage/php/junit.xml
+
+# Exclusions
+sonar.exclusions=vendor/**,tests/**


### PR DESCRIPTION
## Summary

- Removed `-Dsonar.organization` and `-Dsonar.projectKey` args from sonar workflow (the secrets were empty, overriding the properties file with blank values)
- Added `sonar-project.properties` with project key (`catch-oss_silverstripe-csp-logging`) and org (`catch-design`)
- Checkout now uses `workflow_run.head_sha` so the properties file is found when scanning PR branches

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>